### PR TITLE
WIP: Various nix improvements

### DIFF
--- a/esp-idf.nix
+++ b/esp-idf.nix
@@ -3,15 +3,16 @@
 let
   version = "v4.1-dev";
 
-  pypkgs = python-packages: with python-packages; [
-    pyserial
-    click
-    cryptography
-    future
-    pyparsing
-    pyelftools
-    setuptools
-  ];
+  pypkgs = python-packages:
+    with python-packages; [
+      pyserial
+      click
+      cryptography
+      future
+      pyparsing
+      pyelftools
+      setuptools
+    ];
   python = pkgs.python2.withPackages pypkgs;
 
 in stdenv.mkDerivation rec {
@@ -20,14 +21,12 @@ in stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "espressif";
     repo = "esp-idf";
-    rev  = "${version}";
+    rev = "${version}";
     fetchSubmodules = true;
     sha256 = "0d1iqxz1jqz3rrk2c5dq33wp1v71d9190wv3bnigxlp5kcsj0j1w";
   };
 
-  buildInputs = [
-    python
-  ];
+  buildInputs = [ python ];
 
   propagatedBuildInputs = [
     pkgs.cmake
@@ -50,7 +49,8 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "ESP IDF";
-    homepage = https://docs.espressif.com/projects/esp-idf/en/stable/get-started/linux-setup.html;
+    homepage =
+      "https://docs.espressif.com/projects/esp-idf/en/stable/get-started/linux-setup.html";
     license = licenses.gpl3;
   };
 }

--- a/esp32-toolchain.nix
+++ b/esp32-toolchain.nix
@@ -6,15 +6,15 @@ let
     targetPkgs = pkgs: with pkgs; [ zlib ];
     runScript = "";
   };
-in
 
-stdenv.mkDerivation rec {
+in stdenv.mkDerivation rec {
   name = "esp32-toolchain";
   version = "2019r2";
 
   src = fetchurl {
     # https://github.com/espressif/esp-idf/blob/release/v4.1/tools/tools.json#L27
-    url = "https://dl.espressif.com/dl/xtensa-esp32-elf-gcc8_2_0-esp-2019r2-linux-amd64.tar.gz";
+    url =
+      "https://dl.espressif.com/dl/xtensa-esp32-elf-gcc8_2_0-esp-2019r2-linux-amd64.tar.gz";
     sha256 = "1pzv1r9kzizh5gi3gsbs6jg8rs1yqnmf5rbifbivz34cplfprm76";
   };
 
@@ -35,7 +35,8 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "ESP32 toolchain";
-    homepage = https://docs.espressif.com/projects/esp-idf/en/stable/get-started/linux-setup.html;
+    homepage =
+      "https://docs.espressif.com/projects/esp-idf/en/stable/get-started/linux-setup.html";
     license = licenses.gpl3;
   };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,19 +1,12 @@
-{ pkgs ? import <nixpkgs> {} }:
-let 
-  esp-idf = (pkgs.callPackage ./esp-idf.nix {});
-  esp32-toolchain = (pkgs.callPackage ./esp32-toolchain.nix {});
-in
-  pkgs.mkShell {
-    buildInputs = [ 
-      esp-idf
-      esp32-toolchain
-    ];
-    shellHook = ''
-set -e
-
-export IDF_PATH=${esp-idf}
-
-export NIX_CFLAGS_LINK=-lncurses
-export PATH=$PATH:$IDF_PATH/tools
-    '';
+{ pkgs ? import <nixpkgs> { } }:
+let
+  esp-idf = (pkgs.callPackage ./esp-idf.nix { });
+  esp32-toolchain = (pkgs.callPackage ./esp32-toolchain.nix { });
+in pkgs.mkShell {
+  buildInputs = [ esp-idf esp32-toolchain ];
+  shellHook = ''
+    export IDF_PATH=${esp-idf}
+    export NIX_CFLAGS_LINK=-lncurses
+    export PATH=$PATH:$IDF_PATH/tools
+  '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,7 @@ let
 in pkgs.mkShell {
   buildInputs = [ esp-idf esp32-toolchain ];
   shellHook = ''
-    export IDF_PATH=${esp-idf}
+    export IDF_PATH="${esp-idf.outPath}"
     export NIX_CFLAGS_LINK=-lncurses
     export PATH=$PATH:$IDF_PATH/tools
   '';


### PR DESCRIPTION
Few small things:

- The double single-quote syntax for multi-line strings is much more convenient than here docs and will automatically strip leading spaces correctly.
- outPath is "technically more betterer" than just string interpolating the derivation, but meh.

Otherwise looks nice. Idiomatically, nix code is generally put into a nix directory with only a default.nix and/or a shell.nix file staying at the top level. I'll update the MR with pinning nixpkgs explicitly so that the code will be guaranteed to work regardless of you updating your OS. Especially with stuff like this that might not be touched for a year, you want that :p